### PR TITLE
Fix Decimals showing as total supply on wen wallet. Also add commas for longer numbers. 

### DIFF
--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -31,6 +31,7 @@ import {
   ipfsToUrl,
   sendSignedTransaction,
   shortenAddress,
+  formatWithCommas,
 } from "../core/utils";
 import useAssetStore from "../store/assetStore";
 import useConnectionStore from "../store/connectionStore";
@@ -296,7 +297,7 @@ const AssetImageCard = ({
                 )}
                 <Chip
                   label={`Balance: ${
-                    asset.amount / 10 ** assetData.params.decimals
+                    formatWithCommas(asset.amount / 10 ** assetData.params.decimals)
                   }`}
                   size="small"
                   className="absolute bottom-2 right-2"

--- a/src/components/dialogs/AssetSendDialog.tsx
+++ b/src/components/dialogs/AssetSendDialog.tsx
@@ -30,7 +30,9 @@ const AssetSendDialog: React.FC<AssetSendDialogProps> = ({
   asset,
   balance,
 }) => {
-  const [amount, setAmount] = useState(balance.toString());
+  const [amount, setAmount] = useState(
+    (balance / 10 ** asset.params.decimals).toString()
+  );
   const [receiver, setReceiver] = useState("");
   const [loading, setLoading] = useState(false);
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -768,3 +768,10 @@ export async function createAssetTransferTransactions(
 export async function getGenesis() {
   return await algodClient.genesis().do();
 }
+
+export function formatWithCommas(input: number): string {
+  if (isNaN(input)) {
+    return input.toString();
+  }
+  return input.toLocaleString("en-US");
+}

--- a/src/routes/AssetDetail.tsx
+++ b/src/routes/AssetDetail.tsx
@@ -20,6 +20,7 @@ import {
   createAssetOptoutTransactions,
   sendSignedTransaction,
   getAccountAssetData,
+  formatWithCommas,
 } from "../core/utils";
 import { CardMedia } from "@mui/material";
 import { toast } from "react-toastify";
@@ -167,13 +168,6 @@ export default function AssetDetail() {
           "Something went wrong"
       );
     }
-  }
-
-  function formatWithCommas(input: number): string {
-    if (isNaN(input)) {
-      return input.toString();
-    }
-    return input.toLocaleString("en-US");
   }
 
   return (

--- a/src/routes/AssetDetail.tsx
+++ b/src/routes/AssetDetail.tsx
@@ -169,6 +169,13 @@ export default function AssetDetail() {
     }
   }
 
+  function formatWithCommas(input: number): string {
+    if (isNaN(input)) {
+      return input.toString();
+    }
+    return input.toLocaleString("en-US");
+  }
+
   return (
     <div className="bg-asset-detail-bg p-8 text-white rounded-lg mx-4 sm:mx-auto sm:max-w-3xl my-4 md:my-8">
       <h2 className="text-4xl font-bold mb-2 text-center">
@@ -245,7 +252,12 @@ export default function AssetDetail() {
                 {shortenAddress(assetData.params.creator)}
               </a>
             </p>
-            <p className="text-xs">Supply: {assetData.params.total}</p>
+            <p className="text-xs">
+              Supply:{" "}
+              {formatWithCommas(
+                assetData.params.total / Math.pow(10, assetData.params.decimals)
+              )}
+            </p>
             <p className="text-xs">Decimals: {assetData.params.decimals}</p>
             <p className="text-xs">
               Clawback:{" "}
@@ -343,7 +355,11 @@ export default function AssetDetail() {
                           </p>
                           {trait.category === "external_url" ? (
                             <a
-                              href={trait.value.toLowerCase().startsWith("http") ? trait.value : `https://${trait.value}`}
+                              href={
+                                trait.value.toLowerCase().startsWith("http")
+                                  ? trait.value
+                                  : `https://${trait.value}`
+                              }
                               target="_blank"
                               rel="noreferrer noopener"
                               className="text-gray-50 break-all hover:text-green-400 transition-all"


### PR DESCRIPTION
Fix Decimals showing as total supply on wen wallet. Also add commas for longer numbers in asset detail page & homepage. 